### PR TITLE
Fix memory leak

### DIFF
--- a/ttt.c
+++ b/ttt.c
@@ -186,6 +186,7 @@ int get_input(char player)
         x = tolower(line[0]) - 'a';
         y = tolower(line[1]) - '1';
     }
+    free(line);
     return x + 3 * y;
 }
 


### PR DESCRIPTION
Allocate buffer for getline and free memory in `get_input` function

According to the manpage of getline(), 
```
if *lineptr is set to NULL and *n is set to 0 before the call, getline() will allocate a buffer for storing the line. 
This buffer should be freed by the user program even if getline() failed.
```

In the get_input function, add `free(line)` after its usage to prevent memory leaks.