### PR TITLE
Fix memory leak in negamax

### DIFF
--- a/ttt.c
+++ b/ttt.c
@@ -189,6 +189,7 @@ int negamax(char *table, int depth, char player, int alpha, int beta)
         table[best_move] = player;
         record_move(best_move);
     }
+    free((char *)moves);
     return best_score;
 }
 

--- a/ttt.c
+++ b/ttt.c
@@ -3,18 +3,20 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define MAX_MOVES (3 * 3) 
+#define MAX_MOVES (3 * 3)
 
 int move_record[MAX_MOVES];
-int move_count = 0; 
+int move_count = 0;
 
-void record_move(int move) {
+void record_move(int move)
+{
     if (move_count < MAX_MOVES) {
         move_record[move_count++] = move;
     }
 }
 
-void print_moves() {
+void print_moves()
+{
     printf("Moves: ");
     for (int i = 0; i < move_count; i++) {
         int col = move_record[i] % 3;
@@ -185,11 +187,11 @@ int negamax(char *table, int depth, char player, int alpha, int beta)
             break;
     }
 
-    if (depth == 0 && best_move != -1){
+    if (depth == 0 && best_move != -1) {
         table[best_move] = player;
         record_move(best_move);
     }
-    free((char *)moves);
+    free((char *) moves);
     return best_score;
 }
 


### PR DESCRIPTION
By using valgrind, we can find that there are some memory leak problems from the ``negamax`` function doesn't free the malloc'd `moves`.

```
==1415957== 34,704 bytes in 964 blocks are definitely lost in loss record 8 of 8
==1415957==    at 0x48407B4: malloc (vg_replace_malloc.c:381)
==1415957==    by 0x1096D9: available_moves (in /home/hsi/Dropbox/Side/site/_/codes/ttt/ttt)
==1415957==    by 0x109A35: negamax (in /home/hsi/Dropbox/Side/site/_/codes/ttt/ttt)
==1415957==    by 0x109AC3: negamax (in /home/hsi/Dropbox/Side/site/_/codes/ttt/ttt)
==1415957==    by 0x109AC3: negamax (in /home/hsi/Dropbox/Side/site/_/codes/ttt/ttt)
==1415957==    by 0x109AC3: negamax (in /home/hsi/Dropbox/Side/site/_/codes/ttt/ttt)
==1415957==    by 0x109AC3: negamax (in /home/hsi/Dropbox/Side/site/_/codes/ttt/ttt)
==1415957==    by 0x109AC3: negamax (in /home/hsi/Dropbox/Side/site/_/codes/ttt/ttt)
==1415957==    by 0x109AC3: negamax (in /home/hsi/Dropbox/Side/site/_/codes/ttt/ttt)
==1415957==    by 0x109D0D: main (in /home/hsi/Dropbox/Side/site/_/codes/ttt/ttt)
==1415957==
==1415957== LEAK SUMMARY:
==1415957==    definitely lost: 107,064 bytes in 2,974 blocks
==1415957==    indirectly lost: 0 bytes in 0 blocks
==1415957==      possibly lost: 0 bytes in 0 blocks
==1415957==    still reachable: 0 bytes in 0 blocks
==1415957==         suppressed: 0 bytes in 0 blocks
==1415957==
==1415957== ERROR SUMMARY: 8 errors from 8 contexts (suppressed: 0 from 0)
```

This commit fixes the memory leak problem.

```
Moves: A1 -> B2 -> A2 -> A3 -> B1 -> C1
==1417410==
==1417410== HEAP SUMMARY:
==1417410==     in use at exit: 0 bytes in 0 blocks
==1417410==   total heap usage: 2,979 allocs, 2,979 frees, 109,472 bytes allocated
==1417410==
==1417410== All heap blocks were freed -- no leaks are possible
==1417410==
==1417410== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
````