### PR TITLE
Refactor record_move

### DIFF
--- a/ttt.c
+++ b/ttt.c
@@ -15,12 +15,19 @@ static int no_step[2] = {0, 0};
 static int step_forward[2] = {1, 2};
 static int step_backward[2] = {-1, -2};
 
-int move_record[N_GRIDS];
-int move_count = 0;
+static int *move_record = NULL;
+static int move_count = 0;
 
 void record_move(int move)
 {
-    if (move_count < N_GRIDS) {
+    if (move_count == 0)
+        move_record = malloc(sizeof(int));
+    else
+        move_record = realloc(move_record, sizeof(int) * (move_count + 1));
+
+    if (move_record == NULL)
+        exit(1);
+    else {
         move_record[move_count++] = move;
     }
 }
@@ -349,6 +356,8 @@ int main()
         turn = turn == 'X' ? 'O' : 'X';
     }
     print_moves();
+    free(move_record);
     free(table);
+
     return 0;
 }

--- a/ttt.c
+++ b/ttt.c
@@ -21,9 +21,12 @@ static int move_count = 0;
 void record_move(int move)
 {
     if (move_count == 0) {
+        // minimum of 5 moves is required to determine the winner
         move_record = malloc(sizeof(int) * (5));
     } else {
-        move_record = realloc(move_record, sizeof(int) * (move_count + BOARD_SIZE));
+        // Todo : find a better size to resize move_record
+        move_record =
+            realloc(move_record, sizeof(int) * (move_count + BOARD_SIZE));
     }
 
     if (!move_record)

--- a/ttt.c
+++ b/ttt.c
@@ -26,9 +26,8 @@ void record_move(int move)
         move_record = realloc(move_record, sizeof(int) * (move_count + BOARD_SIZE));
     }
 
-    if (move_record == NULL) {
+    if (!move_record)
         exit(1);
-    }
     move_record[move_count++] = move;
 }
 

--- a/ttt.c
+++ b/ttt.c
@@ -20,16 +20,16 @@ static int move_count = 0;
 
 void record_move(int move)
 {
-    if (move_count == 0)
-        move_record = malloc(sizeof(int));
-    else
-        move_record = realloc(move_record, sizeof(int) * (move_count + 1));
-
-    if (move_record == NULL)
-        exit(1);
-    else {
-        move_record[move_count++] = move;
+    if (move_count == 0) {
+        move_record = malloc(sizeof(int) * (5));
+    } else {
+        move_record = realloc(move_record, sizeof(int) * (move_count + BOARD_SIZE));
     }
+
+    if (move_record == NULL) {
+        exit(1);
+    }
+    move_record[move_count++] = move;
 }
 
 void print_moves()


### PR DESCRIPTION
Replace static array declaration with dynamic allocation for move_record

In this pull request, I propose replacing the static declaration of the move_record array with dynamic allocation. The static declaration used to allocate space for a fixed number of moves, assuming a 4x4 game board with 16 possible moves. However, not every game may utilize all 16 moves, leading to potential wasted memory. By dynamically allocating memory based on the actual number of moves, we can optimize space usage and enhance the program's efficiency.