### PR TITLE
Automate code formatting checks

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+CLANG_FORMATER=clang-format
+CLANG_FORMATER_FLAGS=-style=file
+
+# check clang-format installed
+command -v "$CLANG_FORMATER" > /dev/null
+ret=$?
+
+if [[ $ret -ne 0 ]]; then
+    echo -e "\e[31;1m$CLANG_FORMATER not installed...\e[0m"
+    exit $ret
+else
+    # make sure version >= 12
+    $CLANG_FORMATER --version | grep -P ".*version (1[2-9]|[2-9]\d+).*" >> /dev/null
+    ret=$?
+
+    if [[ $ret -ne 0 ]]; then
+        echo -e "\e[31;1m$CLANG_FORMATER version should >= 12 ...\e[0m"
+        exit $ret
+    fi
+fi
+
+# check format (based on sysprog21/lab0-c/.ci/check-format.sh)
+
+SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(c|h)\$")
+
+for file in ${SOURCES};
+do
+    $CLANG_FORMATER $CLANG_FORMATER_FLAGS ${file} > expected-format
+    diff -u -p --label="${file}" --label="expected coding style" ${file} expected-format
+done
+exit $($CLANG_FORMATER --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# make sure no format error
+./.ci/check-format.sh
+ret=$?
+
+echo -ne "Code format check: "
+if [ $ret -ne 0 ]; then
+    echo -e "\e[31;1mFailed, commit aborted...\e[0m"
+    exit $ret
+else
+    echo -e "\e[36;1mPassed!\e[0m"
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # make sure no format error
-./.ci/check-format.sh
+.ci/check-format.sh
 ret=$?
 
 echo -ne "Code format check: "

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,3 +15,14 @@ jobs:
       - name: Check code formatting
         run: |
             ./.ci/check-format.sh
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+            sudo apt-get update -q -y
+            sudo apt-get install -q -y build-essential make
+      - name: default build
+        run: make

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  check-code-format:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+            sudo apt-get update -q -y
+            sudo apt-get install -q -y clang-format
+      - name: Check code formatting
+        run: |
+            ./.ci/check-format.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
             sudo apt-get install -q -y clang-format
       - name: Check code formatting
         run: |
-            ./.ci/check-format.sh
+            .ci/check-format.sh
   build:
     runs-on: ubuntu-22.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 PROG = ttt
 CFLAGS = -Wall -Wextra
 
+GIT_HOOKS := .git/hooks/applied
+
+all: $(GIT_HOOKS) $(PROG)
+
+$(GIT_HOOKS):
+	@scripts/install-git-hooks
+	@echo
+
 $(PROG): $(PROG).c
 	gcc $(CFLAGS) -o $@ $^
 

--- a/scripts/install-git-hooks
+++ b/scripts/install-git-hooks
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+mkdir -p .git/hooks
+
+ln -sf ../../.githooks/pre-commit .git/hooks/pre-commit || exit 1
+chmod +x .git/hooks/pre-commit || exit 1 # fails if dangling symlink
+
+touch .git/hooks/applied || exit 1


### PR DESCRIPTION
This commit use the git pre-commit hook to check and report the code formatting problem in the committed codes. The version of the clang-format is required to be greater than 12 because the use of [`StatementAttributeLikeMacros`](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#statementattributelikemacros).

However, as the directory .git/hooks cannot be tracked by git, additional configuration is required, which is written in the README file.

The reason why not merge the scripts into .githooks/pre-commit is for future expansion (e.g., compilation check and reuse the script for GitHub Action).