### PR TITLE
Expand labels and beautify table

### DIFF
--- a/ttt.c
+++ b/ttt.c
@@ -85,11 +85,17 @@ void draw_board(const char *t)
     }
     if (BOARD_SIZE >= 10)
         printf("-");
+    if (BOARD_SIZE >= 100)
+        printf("-");
     printf("---+-");
     for (int i = 0; i < BOARD_SIZE; i++)
         printf("---");
     printf("\n");
-    printf("     ");
+    if (BOARD_SIZE >= 10)
+        printf(" ");
+    if (BOARD_SIZE >= 100)
+        printf(" ");
+    printf("    ");
     for (int i = 0; i < BOARD_SIZE; i++) {
         // could be more generalized
         if (i < 26)

--- a/ttt.c
+++ b/ttt.c
@@ -50,9 +50,20 @@ void print_moves()
 void draw_board(const char *t)
 {
     for (int i = 0; i < BOARD_SIZE; i++) {
-        printf("%2c | ", '1' + i);
+        if (BOARD_SIZE < 10)
+            printf("%2d | ", i + 1);
+        else if(BOARD_SIZE >= 10 && BOARD_SIZE < 100)
+            printf("%3d | ", i + 1);
+        else
+            printf("%4d | ", i + 1);
+
         for (int j = 0; j < BOARD_SIZE; j++) {
-            printf("\x1b[47m");
+            // make background color alter between high-intensity and standard
+            if ((i + j) & 1U)
+                printf("\x1b[47m");
+            else
+                printf("\x1b[107m");
+
             switch (t[GET_INDEX(i, j)]) {
             case 'O':
                 printf("\x1b[31m");
@@ -72,13 +83,23 @@ void draw_board(const char *t)
         }
         printf("\n");
     }
+    if(BOARD_SIZE >= 10)
+        printf("-");
     printf("---+-");
     for (int i = 0; i < BOARD_SIZE; i++)
         printf("---");
     printf("\n");
-    printf("    ");
-    for (int i = 0; i < BOARD_SIZE; i++)
-        printf(" %2c", 'A' + i);
+    printf("     ");
+    for (int i = 0; i < BOARD_SIZE; i++) {
+        // could be more generalized
+        if (i < 26)
+            printf(" %2c", 'A' + i);
+        else {
+            int k = i / 26 - 1;
+            printf(" %c", 'A' + k);
+            printf("%c", 'A' + i % 26);
+        }
+    }
     printf("\n");
 }
 
@@ -304,20 +325,58 @@ int get_input(char player)
 {
     char *line = NULL;
     size_t line_length = 0;
+    int parseX = 1;
 
-    char x = -1, y = -1;
+    int x = -1, y = -1;
     while (x < 0 || x > (BOARD_SIZE - 1) || y < 0 || y > (BOARD_SIZE - 1)) {
         printf("%c> ", player);
         int r = getline(&line, &line_length, stdin);
         if (r == -1)
             exit(1);
-        if (r < 2)
+        if (r < 2) {
             continue;
-        if (!isdigit(line[1]) || !isalpha(line[0])) {
-            printf("invalid operation\n");
         }
-        x = tolower(line[0]) - 'a';
-        y = tolower(line[1]) - '1';
+        x = 0;
+        y = 0;
+        parseX = 1;
+        for (int i = 0; i < r - 1; i++) {
+            if (isalpha(line[i]) && parseX) {
+                x = x * 26 + (tolower(line[i]) - 'a' + 1);
+                if(x > BOARD_SIZE){
+                    x = BOARD_SIZE + 1; // x could be assigned with any value in [BOARD_SIZE + 1, INT_MAX]
+                    printf("Invalid operation: index exceeds board size\n");
+                    break;
+                }
+                continue;
+            }
+            // input does not have leading alpabets
+            if (x == 0) {
+                printf("Invalid operation: No leading alphabet\n");
+                y = 0;
+                break;
+            }
+            parseX = 0;
+            if (isdigit(line[i])) {
+                y = y * 10 + line[i] - '0';
+                if(y > BOARD_SIZE){
+                    y = BOARD_SIZE + 1; // y could be assigned with any value in [BOARD_SIZE + 1, INT_MAX]
+                    printf("Invalid operation: index exceeds board size\n");
+                    break;
+                }
+                continue;
+            }
+            // any other char is invalid
+            // ant non-digit char during digit parsing is invalid
+            // TODO: Error message could be better by separating these two cases
+            if (i < r - 1) {
+                printf("invalid operation\n");
+                x = 0;
+                y = 0;
+                break;
+            }
+        }
+        x -= 1;
+        y -= 1;
     }
     free(line);
     return GET_INDEX(y, x);

--- a/ttt.c
+++ b/ttt.c
@@ -52,7 +52,7 @@ void draw_board(const char *t)
     for (int i = 0; i < BOARD_SIZE; i++) {
         if (BOARD_SIZE < 10)
             printf("%2d | ", i + 1);
-        else if(BOARD_SIZE >= 10 && BOARD_SIZE < 100)
+        else if (BOARD_SIZE >= 10 && BOARD_SIZE < 100)
             printf("%3d | ", i + 1);
         else
             printf("%4d | ", i + 1);
@@ -83,7 +83,7 @@ void draw_board(const char *t)
         }
         printf("\n");
     }
-    if(BOARD_SIZE >= 10)
+    if (BOARD_SIZE >= 10)
         printf("-");
     printf("---+-");
     for (int i = 0; i < BOARD_SIZE; i++)
@@ -333,17 +333,17 @@ int get_input(char player)
         int r = getline(&line, &line_length, stdin);
         if (r == -1)
             exit(1);
-        if (r < 2) {
+        if (r < 2)
             continue;
-        }
         x = 0;
         y = 0;
         parseX = 1;
         for (int i = 0; i < r - 1; i++) {
             if (isalpha(line[i]) && parseX) {
                 x = x * 26 + (tolower(line[i]) - 'a' + 1);
-                if(x > BOARD_SIZE){
-                    x = BOARD_SIZE + 1; // x could be assigned with any value in [BOARD_SIZE + 1, INT_MAX]
+                if (x > BOARD_SIZE) {
+                    x = BOARD_SIZE + 1;  // x could be assigned with any value
+                                         // in [BOARD_SIZE + 1, INT_MAX]
                     printf("Invalid operation: index exceeds board size\n");
                     break;
                 }
@@ -358,8 +358,9 @@ int get_input(char player)
             parseX = 0;
             if (isdigit(line[i])) {
                 y = y * 10 + line[i] - '0';
-                if(y > BOARD_SIZE){
-                    y = BOARD_SIZE + 1; // y could be assigned with any value in [BOARD_SIZE + 1, INT_MAX]
+                if (y > BOARD_SIZE) {
+                    y = BOARD_SIZE + 1;  // y could be assigned with any value
+                                         // in [BOARD_SIZE + 1, INT_MAX]
                     printf("Invalid operation: index exceeds board size\n");
                     break;
                 }


### PR DESCRIPTION
Originially labels at left side and bottom could be non-alphanumeric or even unprintable when board size is larger than 10. Also, original input is capped in [0, 9] for rows and [a, z] for columns.

This commit expands label in two aspects: label display and input. Column label display now supports from 'A' to 'ZZ' (676 columns), and row label display supports from '1' to '999'. I suggest not to support further since it would exceeds the limitation of human eyes. So printing is hard coded under this limit.

Any cell in the table now can be selected by typing in the corresponding label value. Input is decoupled with label display so it is still functional when board size exceeds the limit of label. Note that the variables to store parsed x, y input is int so board size is capped to INT_MAT/26 - 25 (otherwise the variable to store input would overflow), or the maximum size of table. To support further, I suggest make the table hierarchical like virtual memory to avoid unsupported board size. Nicer invalid operation messages are also provided now.

To have better visibility, adjacent cells in the table now have color alternation between high-intensity and standard.