### PR TITLE
Optimize search efficiency with Zobrist hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ $(GIT_HOOKS):
 
 OBJS := \
 	game.o \
+	mt19937-64.o \
 	agents/negamax.o \
 	main.o
 deps := $(OBJS:%.o=%.d)

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ $(GIT_HOOKS):
 OBJS := \
 	game.o \
 	mt19937-64.o \
+	zobrist.o \
 	agents/negamax.o \
 	main.o
 deps := $(OBJS:%.o=%.d)

--- a/agents/negamax.h
+++ b/agents/negamax.h
@@ -4,4 +4,5 @@ typedef struct {
     int score, move;
 } move_t;
 
+void negamax_init();
 move_t negamax_predict(char *table, char player);

--- a/list.h
+++ b/list.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifndef container_of
+#ifdef __HAVE_TYPEOF
+#define container_of(ptr, type, member)                            \
+    __extension__({                                                \
+        const __typeof__(((type *) 0)->member) *__pmember = (ptr); \
+        (type *) ((char *) __pmember - offsetof(type, member));    \
+    })
+#else
+#define container_of(ptr, type, member) \
+    ((type *) ((char *) (ptr) - (offsetof(type, member))))
+#endif
+#endif
+
+struct hlist_head {
+    struct hlist_node *first;
+};
+
+struct hlist_node {
+    struct hlist_node *next, **pprev;
+};
+
+#define INIT_HLIST_HEAD(ptr) ((ptr)->first = NULL)
+
+static inline void INIT_HLIST_NODE(struct hlist_node *h)
+{
+    h->next = NULL;
+    h->pprev = NULL;
+}
+
+static inline int hlist_empty(const struct hlist_head *h)
+{
+    return !h->first;
+}
+
+static inline void hlist_add_head(struct hlist_node *n, struct hlist_head *h)
+{
+    struct hlist_node *first = h->first;
+    n->next = first;
+    if (first)
+        first->pprev = &n->next;
+
+    h->first = n;
+    n->pprev = &h->first;
+}
+
+static inline bool hlist_unhashed(const struct hlist_node *h)
+{
+    return !h->pprev;
+}
+
+static inline void hlist_del(struct hlist_node *n)
+{
+    struct hlist_node *next = n->next;
+    struct hlist_node **pprev = n->pprev;
+
+    *pprev = next;
+    if (next)
+        next->pprev = pprev;
+}
+
+static inline void hlist_del_init(struct hlist_node *n)
+{
+    if (hlist_unhashed(n))
+        return;
+    hlist_del(n);
+    INIT_HLIST_NODE(n);
+}
+
+#define hlist_entry(ptr, type, member) container_of(ptr, type, member)
+
+#ifdef __HAVE_TYPEOF
+#define hlist_entry_safe(ptr, type, member)                  \
+    ({                                                       \
+        typeof(ptr) ____ptr = (ptr);                         \
+        ____ptr ? hlist_entry(____ptr, type, member) : NULL; \
+    })
+#else
+#define hlist_entry_safe(ptr, type, member) \
+    (ptr) ? hlist_entry(ptr, type, member) : NULL
+#endif
+
+#ifdef __HAVE_TYPEOF
+#define hlist_for_each_entry(pos, head, member)                              \
+    for (pos = hlist_entry_safe((head)->first, typeof(*(pos)), member); pos; \
+         pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member))
+#else
+#define hlist_for_each_entry(pos, head, member, type)              \
+    for (pos = hlist_entry_safe((head)->first, type, member); pos; \
+         pos = hlist_entry_safe((pos)->member.next, type, member))
+#endif

--- a/main.c
+++ b/main.c
@@ -151,6 +151,8 @@ int main()
     char turn = 'X';
     char ai = 'O';
 
+    negamax_init();
+
     while (1) {
         char win = check_win(table);
         if (win == 'D') {

--- a/mt19937-64.c
+++ b/mt19937-64.c
@@ -1,0 +1,116 @@
+/*
+   A C-program for MT19937-64 (2004/9/29 version).
+   Coded by Takuji Nishimura and Makoto Matsumoto.
+
+   This is a 64-bit version of Mersenne Twister pseudorandom number
+   generator.
+
+   Before using, initialize the state by using init_genrand64(seed)
+   or init_by_array64(init_key, key_length).
+
+   Copyright (C) 2004, Makoto Matsumoto and Takuji Nishimura,
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+     1. Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+     2. Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+
+     3. The names of its contributors may not be used to endorse or promote
+        products derived from this software without specific prior written
+        permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER
+   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   References:
+   T. Nishimura, ``Tables of 64-bit Mersenne Twisters''
+     ACM Transactions on Modeling and
+     Computer Simulation 10. (2000) 348--357.
+   M. Matsumoto and T. Nishimura,
+     ``Mersenne Twister: a 623-dimensionally equidistributed
+       uniform pseudorandom number generator''
+     ACM Transactions on Modeling and
+     Computer Simulation 8. (Jan. 1998) 3--30.
+
+   Any feedback is very welcome.
+   http://www.math.hiroshima-u.ac.jp/~m-mat/MT/emt.html
+   email: m-mat @ math.sci.hiroshima-u.ac.jp (remove spaces)
+*/
+
+#include "mt19937-64.h"
+
+#define NN 312
+#define MM 156
+#define MATRIX_A 0xB5026F5AA96619E9ULL
+#define UM 0xFFFFFFFF80000000ULL /* Most significant 33 bits */
+#define LM 0x7FFFFFFFULL         /* Least significant 31 bits */
+
+
+/* The array for the state vector */
+static unsigned long long mt[NN];
+/* mti==NN+1 means mt[NN] is not initialized */
+static int mti = NN + 1;
+
+/* initializes mt[NN] with a seed */
+void mt19937_init(unsigned long long seed)
+{
+    mt[0] = seed;
+    for (mti = 1; mti < NN; mti++)
+        mt[mti] =
+            (6364136223846793005ULL * (mt[mti - 1] ^ (mt[mti - 1] >> 62)) +
+             mti);
+}
+
+/* generates a random number on [0, 2^64-1]-interval */
+unsigned long long mt19937_rand(void)
+{
+    int i;
+    unsigned long long x;
+    static unsigned long long mag01[2] = {0ULL, MATRIX_A};
+
+    if (mti >= NN) { /* generate NN words at one time */
+
+        /* if mt19937_init() has not been called, */
+        /* a default initial seed is used     */
+        if (mti == NN + 1)
+            mt19937_init(5489ULL);
+
+        for (i = 0; i < NN - MM; i++) {
+            x = (mt[i] & UM) | (mt[i + 1] & LM);
+            mt[i] = mt[i + MM] ^ (x >> 1) ^ mag01[(int) (x & 1ULL)];
+        }
+        for (; i < NN - 1; i++) {
+            x = (mt[i] & UM) | (mt[i + 1] & LM);
+            mt[i] = mt[i + (MM - NN)] ^ (x >> 1) ^ mag01[(int) (x & 1ULL)];
+        }
+        x = (mt[NN - 1] & UM) | (mt[0] & LM);
+        mt[NN - 1] = mt[MM - 1] ^ (x >> 1) ^ mag01[(int) (x & 1ULL)];
+
+        mti = 0;
+    }
+
+    x = mt[mti++];
+
+    x ^= (x >> 29) & 0x5555555555555555ULL;
+    x ^= (x << 17) & 0x71D67FFFEDA60000ULL;
+    x ^= (x << 37) & 0xFFF7EEE000000000ULL;
+    x ^= (x >> 43);
+
+    return x;
+}

--- a/mt19937-64.h
+++ b/mt19937-64.h
@@ -1,0 +1,7 @@
+#pragma once
+
+/* initializes mt[NN] with a seed */
+void mt19937_init(unsigned long long seed);
+
+/* generates a random number on [0, 2^64-1]-interval */
+unsigned long long mt19937_rand(void);

--- a/zobrist.c
+++ b/zobrist.c
@@ -1,0 +1,69 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#include "mt19937-64.h"
+#include "zobrist.h"
+
+unsigned long long zobrist_table[N_GRIDS][2];
+
+#define HASH(key) ((key) % HASH_TABLE_SIZE)
+
+static struct hlist_head *hash_table;
+
+void zobrist_init(void)
+{
+    int i;
+    for (i = 0; i < N_GRIDS; i++) {
+        zobrist_table[i][0] = mt19937_rand();
+        zobrist_table[i][1] = mt19937_rand();
+    }
+    hash_table = malloc(sizeof(struct hlist_head) * HASH_TABLE_SIZE);
+    assert(hash_table);
+    for (i = 0; i < HASH_TABLE_SIZE; i++)
+        INIT_HLIST_HEAD(&hash_table[i]);
+}
+
+zobrist_entry_t *zobrist_get(unsigned long long key)
+{
+    unsigned long long hash_key = HASH(key);
+
+    if (hlist_empty(&hash_table[hash_key]))
+        return NULL;
+
+    zobrist_entry_t *entry = NULL;
+#ifdef __HAVE_TYPEOF
+    hlist_for_each_entry (entry, &hash_table[hash_key], ht_list)
+#else
+    hlist_for_each_entry (entry, &hash_table[hash_key], ht_list,
+                          zobrist_entry_t)
+#endif
+    {
+        if (entry->key == key)
+            return entry;
+    }
+    return NULL;
+}
+
+void zobrist_put(unsigned long long key, int score, int move)
+{
+    unsigned long long hash_key = HASH(key);
+    zobrist_entry_t *new_entry = malloc(sizeof(zobrist_entry_t));
+    assert(new_entry);
+    new_entry->key = key;
+    new_entry->move = move;
+    new_entry->score = score;
+    hlist_add_head(&new_entry->ht_list, &hash_table[hash_key]);
+}
+
+void zobrist_clear(void)
+{
+    for (int i = 0; i < HASH_TABLE_SIZE; i++) {
+        while (!hlist_empty(&hash_table[i])) {
+            zobrist_entry_t *entry;
+            entry = hlist_entry(hash_table[i].first, zobrist_entry_t, ht_list);
+            hlist_del(&entry->ht_list);
+            free(entry);
+        }
+        INIT_HLIST_HEAD(&hash_table[i]);
+    }
+}

--- a/zobrist.h
+++ b/zobrist.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "game.h"
+#include "list.h"
+
+#define HASH_TABLE_SIZE ((int) 1e6 + 3)  // choose a large prime number
+
+extern unsigned long long zobrist_table[N_GRIDS][2];
+
+typedef struct {
+    unsigned long long key;
+    int score;
+    int move;
+    struct hlist_node ht_list;
+} zobrist_entry_t;
+
+void zobrist_init(void);
+zobrist_entry_t *zobrist_get(unsigned long long key);
+void zobrist_put(unsigned long long key, int score, int move);
+void zobrist_clear(void);


### PR DESCRIPTION
Implemented Zobrist hash to reduce the number of redundant searches for identical game states.

For example, when the first player plays in cell b2, the search count has been reduced from 66197 to 37078.

While this optimization provides notable performance gains, it comes with the trade-off of increased memory usage due to the need for a hash table. Additionally, collision occurrences cannot be completely eliminated, with the probability estimated at approximately 1/sqrt(HASH_TABLE_SIZE).

Link: https://www.chessprogramming.org/Zobrist_Hashing