### PR TITLE
Fix 'getline' warning with #define _GNU_SOURCE

### DIFF
--- a/ttt.c
+++ b/ttt.c
@@ -1,3 +1,7 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <assert.h>
 #include <ctype.h>
 #include <stdio.h>


### PR DESCRIPTION
The compilation process was generating a warning regarding the implicit declaration of the 'getline' function, which is not part of the C language standard but is defined by POSIX. To address this issue and eliminate the warning, the patch introduces the inclusion of '#define _GNU_SOURCE' in the code.