### PR TITLE
Correct eval_line_segment_score

### DIFF
--- a/ttt.c
+++ b/ttt.c
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -192,6 +193,16 @@ int *available_moves(char *table)
     return moves;
 }
 
+bool is_consecutive(int score, int x)
+{
+    for (int i = 0; i < GOAL - 1; i++) {
+        if (score == x)
+            return true;
+        x *= 10;
+    }
+    return false;
+}
+
 int eval_line_segment_score(const char *table,
                             char player,
                             int i,
@@ -203,7 +214,7 @@ int eval_line_segment_score(const char *table,
         char curr =
             table[GET_INDEX(i + k * line.i_shift, j + k * line.j_shift)];
         if (curr == player) {
-            if (score == -1) {
+            if (is_consecutive(score, -1)) {
                 score = 0;
                 break;
             }
@@ -212,7 +223,7 @@ int eval_line_segment_score(const char *table,
             else
                 score = 1;
         } else if (curr != ' ') {
-            if (score == 1) {
+            if (is_consecutive(score, 1)) {
                 score = 0;
                 break;
             }


### PR DESCRIPTION
I found that there is some error in `get_score` function.
Ex : 
BOARD_SIZE=3
GOAL=3
```
 1 |          
 2 |          
 3 |  X  X  ○ 
---+----------
      A  B  C
```
Using the `get_score` function for 'O' in current version would score it 101.
But the original version would score it 1.

In `eval_line_segment_score`, We can not only check score is `1` or `-1` which means the consecutive length is 1 but also check longer length.