### PR TITLE
Separate agents from game logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROG = ttt
-CFLAGS = -Wall -Wextra -std=c11
+CFLAGS = -Wall -Wextra -std=c11 -I .
 
 GIT_HOOKS := .git/hooks/applied
 
@@ -9,7 +9,7 @@ $(GIT_HOOKS):
 	@scripts/install-git-hooks
 	@echo
 
-$(PROG): $(PROG).c
+$(PROG): $(PROG).c game.c agents/negamax.c
 	gcc $(CFLAGS) -o $@ $^
 
 clean:

--- a/agents/negamax.c
+++ b/agents/negamax.c
@@ -1,0 +1,125 @@
+#include <assert.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "game.h"
+#include "negamax.h"
+
+#define MAX_SEARCH_DEPTH 6
+
+static int history_score_sum[N_GRIDS];
+static int history_count[N_GRIDS];
+
+static int cmp_moves(const void *a, const void *b)
+{
+    int *_a = (int *) a, *_b = (int *) b;
+    int score_a = 0, score_b = 0;
+
+    if (history_count[*_a])
+        score_a = history_score_sum[*_a] / history_count[*_a];
+    if (history_count[*_b])
+        score_b = history_score_sum[*_b] / history_count[*_b];
+    return score_b - score_a;
+}
+
+static int eval_line_segment_score(const char *table,
+                                   char player,
+                                   int i,
+                                   int j,
+                                   line_t line)
+{
+    int score = 0;
+    for (int k = 0; k < GOAL; k++) {
+        char curr =
+            table[GET_INDEX(i + k * line.i_shift, j + k * line.j_shift)];
+        if (curr == player) {
+            if (score < 0)
+                return 0;
+            if (score)
+                score *= 10;
+            else
+                score = 1;
+        } else if (curr != ' ') {
+            if (score > 0)
+                return 0;
+            if (score)
+                score *= 10;
+            else
+                score = -1;
+        }
+    }
+    return score;
+}
+
+static int get_score(const char *table, char player)
+{
+    int score = 0;
+    for (int i_line = 0; i_line < 4; ++i_line) {
+        line_t line = lines[i_line];
+        for (int i = line.i_lower_bound; i < line.i_upper_bound; ++i) {
+            for (int j = line.j_lower_bound; j < line.j_upper_bound; ++j) {
+                score += eval_line_segment_score(table, player, i, j, line);
+            }
+        }
+    }
+    return score;
+}
+
+static move_t negamax(char *table, int depth, char player, int alpha, int beta)
+{
+    if (check_win(table) != ' ' || depth == 0) {
+        move_t result = {get_score(table, player), -1};
+        return result;
+    }
+
+    int score;
+    move_t best_move = {-10000, -1};
+    int *moves = available_moves(table);
+    int n_moves = 0;
+    while (n_moves < N_GRIDS && moves[n_moves] != -1)
+        ++n_moves;
+    qsort(moves, n_moves, sizeof(int), cmp_moves);
+    for (int i = 0; i < n_moves; i++) {
+        table[moves[i]] = player;
+        if (!i)  // do a full search on the first move
+            score = -negamax(table, depth - 1, player == 'X' ? 'O' : 'X', -beta,
+                             -alpha)
+                         .score;
+        else {
+            // do a null-window search on the rest of the moves
+            score = -negamax(table, depth - 1, player == 'X' ? 'O' : 'X',
+                             -alpha - 1, -alpha)
+                         .score;
+            if (alpha < score && score < beta)  // do a full re-search
+                score = -negamax(table, depth - 1, player == 'X' ? 'O' : 'X',
+                                 -beta, -score)
+                             .score;
+        }
+        history_count[moves[i]]++;
+        history_score_sum[moves[i]] += score;
+        if (score > best_move.score) {
+            best_move.score = score;
+            best_move.move = moves[i];
+        }
+        table[moves[i]] = ' ';
+        if (score > alpha)
+            alpha = score;
+        if (alpha >= beta)
+            break;
+    }
+
+    free((char *) moves);
+    return best_move;
+}
+
+move_t negamax_predict(char *table, char player)
+{
+    memset(history_score_sum, 0, sizeof(history_score_sum));
+    memset(history_count, 0, sizeof(history_count));
+    move_t result;
+    for (int depth = 2; depth <= MAX_SEARCH_DEPTH; depth += 2)
+        result = negamax(table, depth, player, -100000, 100000);
+    return result;
+}

--- a/agents/negamax.h
+++ b/agents/negamax.h
@@ -1,0 +1,7 @@
+#pragma once
+
+typedef struct {
+    int score, move;
+} move_t;
+
+move_t negamax_predict(char *table, char player);

--- a/game.c
+++ b/game.c
@@ -1,0 +1,75 @@
+#include <assert.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "game.h"
+
+#define LOOKUP(table, i, j, else_value)                         \
+    ((i) < 0 || (j) < 0 || (i) > BOARD_SIZE || (j) > BOARD_SIZE \
+         ? (else_value)                                         \
+         : (table)[GET_INDEX(i, j)])
+
+_Static_assert(BOARD_SIZE <= 26, "Board size must not be greater than 26");
+_Static_assert(BOARD_SIZE > 0, "Board size must be greater than 0");
+_Static_assert(GOAL <= BOARD_SIZE, "Goal must not be greater than board size");
+_Static_assert(GOAL > 0, "Goal must be greater than 0");
+_Static_assert(ALLOW_EXCEED == 0 || ALLOW_EXCEED == 1,
+               "ALLOW_EXCEED must be a boolean that is 0 or 1");
+
+const line_t lines[4] = {
+    {1, 0, 0, 0, BOARD_SIZE - GOAL + 1, BOARD_SIZE},             // ROW
+    {0, 1, 0, 0, BOARD_SIZE, BOARD_SIZE - GOAL + 1},             // COL
+    {1, 1, 0, 0, BOARD_SIZE - GOAL + 1, BOARD_SIZE - GOAL + 1},  // PRIMARY
+    {1, -1, 0, GOAL - 1, BOARD_SIZE - GOAL + 1, BOARD_SIZE},     // SECONDARY
+};
+
+static char check_line_segment_win(const char *t, int i, int j, line_t line)
+{
+    char last = t[GET_INDEX(i, j)];
+    if (last == ' ')
+        return ' ';
+    for (int k = 1; k < GOAL; k++) {
+        if (last != t[GET_INDEX(i + k * line.i_shift, j + k * line.j_shift)]) {
+            return ' ';
+        }
+    }
+#if !ALLOW_EXCEED
+    if (last == LOOKUP(t, i - line.i_shift, j - line.j_shift, ' ') ||
+        last ==
+            LOOKUP(t, i + GOAL * line.i_shift, j + GOAL * line.j_shift, ' '))
+        return ' ';
+#endif
+    return last;
+}
+
+char check_win(char *t)
+{
+    for (int i_line = 0; i_line < 4; ++i_line) {
+        line_t line = lines[i_line];
+        for (int i = line.i_lower_bound; i < line.i_upper_bound; ++i) {
+            for (int j = line.j_lower_bound; j < line.j_upper_bound; ++j) {
+                char win = check_line_segment_win(t, i, j, line);
+                if (win != ' ')
+                    return win;
+            }
+        }
+    }
+    for (int i = 0; i < N_GRIDS; i++)
+        if (t[i] == ' ')
+            return ' ';
+    return 'D';
+}
+
+int *available_moves(char *table)
+{
+    int *moves = malloc(N_GRIDS * sizeof(int));
+    int m = 0;
+    for (int i = 0; i < N_GRIDS; i++)
+        if (table[i] == ' ')
+            moves[m++] = i;
+    if (m < N_GRIDS)
+        moves[m] = -1;
+    return moves;
+}

--- a/game.h
+++ b/game.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#define BOARD_SIZE 4
+#define GOAL 3
+#define ALLOW_EXCEED 1
+#define N_GRIDS (BOARD_SIZE * BOARD_SIZE)
+#define GET_INDEX(i, j) ((i) * (BOARD_SIZE) + (j))
+#define GET_COL(x) ((x) % BOARD_SIZE)
+#define GET_ROW(x) ((x) / BOARD_SIZE)
+
+typedef struct {
+    int i_shift, j_shift;
+    int i_lower_bound, j_lower_bound, i_upper_bound, j_upper_bound;
+} line_t;
+
+extern const line_t lines[4];
+
+int *available_moves(char *table);
+char check_win(char *t);

--- a/ttt.c
+++ b/ttt.c
@@ -9,62 +9,18 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define MAX_SEARCH_DEPTH 6
-#define BOARD_SIZE 4
-#define GOAL 3
-#define ALLOW_EXCEED 1
-#define N_GRIDS (BOARD_SIZE * BOARD_SIZE)
-#define GET_INDEX(i, j) ((i) * (BOARD_SIZE) + (j))
-#define GET_COL(x) ((x) % BOARD_SIZE)
-#define GET_ROW(x) ((x) / BOARD_SIZE)
-#define LOOKUP(table, i, j, else_value)                         \
-    ((i) < 0 || (j) < 0 || (i) > BOARD_SIZE || (j) > BOARD_SIZE \
-         ? (else_value)                                         \
-         : (table)[GET_INDEX(i, j)])
+#include "agents/negamax.h"
+#include "game.h"
 
-_Static_assert(BOARD_SIZE <= 26, "Board size must not be greater than 26");
-_Static_assert(BOARD_SIZE > 0, "Board size must be greater than 0");
-_Static_assert(GOAL <= BOARD_SIZE, "Goal must not be greater than board size");
-_Static_assert(GOAL > 0, "Goal must be greater than 0");
-_Static_assert(ALLOW_EXCEED == 0 || ALLOW_EXCEED == 1,
-               "ALLOW_EXCEED must be a boolean that is 0 or 1");
-
-typedef struct {
-    int i_shift, j_shift;
-    int i_lower_bound, j_lower_bound, i_upper_bound, j_upper_bound;
-} line_t;
-static line_t lines[4] = {
-    {1, 0, 0, 0, BOARD_SIZE - GOAL + 1, BOARD_SIZE},             // ROW
-    {0, 1, 0, 0, BOARD_SIZE, BOARD_SIZE - GOAL + 1},             // COL
-    {1, 1, 0, 0, BOARD_SIZE - GOAL + 1, BOARD_SIZE - GOAL + 1},  // PRIMARY
-    {1, -1, 0, GOAL - 1, BOARD_SIZE - GOAL + 1, BOARD_SIZE},     // SECONDARY
-};
-
-static int *move_record = NULL;
+static int move_record[N_GRIDS];
 static int move_count = 0;
 
-static int history_score_sum[N_GRIDS];
-static int history_count[N_GRIDS];
-
-void record_move(int move)
+static void record_move(int move)
 {
-    static int n_move_records = 0;
-    if (move_count == 0) {
-        // minimum of 5 moves is required to determine the winner
-        n_move_records = 5;
-        move_record = malloc(sizeof(int) * (5));
-    } else if (move_count == n_move_records) {
-        // TODO: find a better size to resize move_record
-        n_move_records = move_count + BOARD_SIZE;
-        move_record = realloc(move_record, sizeof(int) * n_move_records);
-    }
-
-    if (!move_record)
-        exit(1);
     move_record[move_count++] = move;
 }
 
-void print_moves()
+static void print_moves()
 {
     printf("Moves: ");
     for (int i = 0; i < move_count; i++) {
@@ -77,7 +33,7 @@ void print_moves()
     printf("\n");
 }
 
-void draw_board(const char *t)
+static void draw_board(const char *t)
 {
     for (int i = 0; i < BOARD_SIZE; i++) {
         if (BOARD_SIZE < 10)
@@ -131,173 +87,7 @@ void draw_board(const char *t)
     printf("\n");
 }
 
-char check_line_segment_win(const char *t, int i, int j, line_t line)
-{
-    char last = t[GET_INDEX(i, j)];
-    if (last == ' ')
-        return ' ';
-    for (int k = 1; k < GOAL; k++) {
-        if (last != t[GET_INDEX(i + k * line.i_shift, j + k * line.j_shift)]) {
-            return ' ';
-        }
-    }
-#if !(ALLOW_EXCEED)
-    if (last == LOOKUP(t, i - line.i_shift, j - line.j_shift, ' ') ||
-        last ==
-            LOOKUP(t, i + GOAL * line.i_shift, j + GOAL * line.j_shift, ' '))
-        return ' ';
-#endif
-    return last;
-}
-
-char check_win(char *t)
-{
-    for (int i_line = 0; i_line < 4; ++i_line) {
-        line_t line = lines[i_line];
-        for (int i = line.i_lower_bound; i < line.i_upper_bound; ++i) {
-            for (int j = line.j_lower_bound; j < line.j_upper_bound; ++j) {
-                char win = check_line_segment_win(t, i, j, line);
-                if (win != ' ')
-                    return win;
-            }
-        }
-    }
-    for (int i = 0; i < N_GRIDS; i++)
-        if (t[i] == ' ')
-            return ' ';
-    return 'D';
-}
-
-int cmp_moves(const void *a, const void *b)
-{
-    int *_a = (int *) a, *_b = (int *) b;
-    int score_a = 0, score_b = 0;
-
-    if (history_count[*_a])
-        score_a = history_score_sum[*_a] / history_count[*_a];
-    if (history_count[*_b])
-        score_b = history_score_sum[*_b] / history_count[*_b];
-    return score_b - score_a;
-}
-
-int *available_moves(char *table)
-{
-    int *moves = malloc(N_GRIDS * sizeof(int));
-    int m = 0;
-    for (int i = 0; i < N_GRIDS; i++)
-        if (table[i] == ' ')
-            moves[m++] = i;
-    if (m < N_GRIDS)
-        moves[m] = -1;
-    qsort(moves, m, sizeof(int), cmp_moves);
-    return moves;
-}
-
-bool is_consecutive(int score, int x)
-{
-    for (int i = 0; i < GOAL - 1; i++) {
-        if (score == x)
-            return true;
-        x *= 10;
-    }
-    return false;
-}
-
-int eval_line_segment_score(const char *table,
-                            char player,
-                            int i,
-                            int j,
-                            line_t line)
-{
-    int score = 0;
-    for (int k = 0; k < GOAL; k++) {
-        char curr =
-            table[GET_INDEX(i + k * line.i_shift, j + k * line.j_shift)];
-        if (curr == player) {
-            if (is_consecutive(score, -1)) {
-                score = 0;
-                break;
-            }
-            if (score)
-                score *= 10;
-            else
-                score = 1;
-        } else if (curr != ' ') {
-            if (is_consecutive(score, 1)) {
-                score = 0;
-                break;
-            }
-            if (score)
-                score *= 10;
-            else
-                score = -1;
-        }
-    }
-    return score;
-}
-
-int get_score(const char *table, char player)
-{
-    int score = 0;
-    for (int i_line = 0; i_line < 4; ++i_line) {
-        line_t line = lines[i_line];
-        for (int i = line.i_lower_bound; i < line.i_upper_bound; ++i) {
-            for (int j = line.j_lower_bound; j < line.j_upper_bound; ++j) {
-                score += eval_line_segment_score(table, player, i, j, line);
-            }
-        }
-    }
-    return score;
-}
-
-int negamax(char *table, int depth, char player, int alpha, int beta)
-{
-    if (check_win(table) != ' ')
-        return get_score(table, player);
-    if (depth == 0)
-        return get_score(table, player);
-
-    int score;
-    int best_score = -10000;
-    int best_move = -1;
-    const int *moves = available_moves(table);
-    for (int i = 0; i < N_GRIDS; i++) {
-        if (moves[i] == -1)
-            break;
-        table[moves[i]] = player;
-        if (!i)  // do a full search on the first move
-            score = -negamax(table, depth - 1, player == 'X' ? 'O' : 'X', -beta,
-                             -alpha);
-        else {
-            // do a null-window search on the rest of the moves
-            score = -negamax(table, depth - 1, player == 'X' ? 'O' : 'X',
-                             -alpha - 1, -alpha);
-            if (alpha < score && score < beta)  // do a full re-search
-                score = -negamax(table, depth - 1, player == 'X' ? 'O' : 'X',
-                                 -beta, -score);
-        }
-        history_count[moves[i]]++;
-        history_score_sum[moves[i]] += score;
-        if (score > best_score) {
-            best_score = score;
-            best_move = moves[i];
-        }
-        table[moves[i]] = ' ';
-        if (score > alpha)
-            alpha = score;
-        if (alpha >= beta)
-            break;
-    }
-
-    if (depth == MAX_SEARCH_DEPTH && best_move != -1) {
-        table[best_move] = player;
-        record_move(best_move);
-    }
-    free((char *) moves);
-    return best_score;
-}
-
-int get_input(char player)
+static int get_input(char player)
 {
     char *line = NULL;
     size_t line_length = 0;
@@ -358,10 +148,8 @@ int get_input(char player)
 
 int main()
 {
-    char *table = malloc(sizeof(char) * N_GRIDS);
-    if (!table)
-        return -1;
-    memset(table, ' ', sizeof(char) * N_GRIDS);
+    char table[N_GRIDS];
+    memset(table, ' ', N_GRIDS);
     char turn = 'X';
     char ai = 'O';
 
@@ -378,10 +166,11 @@ int main()
         }
 
         if (turn == ai) {
-            memset(history_score_sum, 0, sizeof(history_score_sum));
-            memset(history_count, 0, sizeof(history_count));
-            for (int depth = 2; depth <= MAX_SEARCH_DEPTH; depth += 2)
-                negamax(table, depth, ai, -100000, 100000);
+            int move = negamax_predict(table, ai).move;
+            if (move != -1) {
+                table[move] = ai;
+                record_move(move);
+            }
         } else {
             draw_board(table);
             int move;
@@ -398,8 +187,6 @@ int main()
         turn = turn == 'X' ? 'O' : 'X';
     }
     print_moves();
-    free(move_record);
-    free(table);
 
     return 0;
 }


### PR DESCRIPTION
In this commit, I split the original `ttt.c`, making it easier to add new agents. To achieve this, I also made the following changes:
* Introduced `move_t` to make `negamax` a pure function.
* Moved `qsort` out from `available_moves` to make it a part of the game logic.

Additionally, I declared `table` and `move_record` as static arrays because they are unnecessary to be dynamically allocated.

I also noticed #29, and I made some modifications to it without changing its score; specifically, I changed
`is_consecutive(score, -1)` to `score < 0`, and vice versa.