### PR TITLE
Replace unsigned long long with uint64_t

### DIFF
--- a/agents/negamax.c
+++ b/agents/negamax.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <ctype.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,7 +14,7 @@
 static int history_score_sum[N_GRIDS];
 static int history_count[N_GRIDS];
 
-static unsigned long long hash_value;
+static uint64_t hash_value;
 
 static int cmp_moves(const void *a, const void *b)
 {

--- a/mt19937-64.c
+++ b/mt19937-64.c
@@ -63,12 +63,12 @@
 
 
 /* The array for the state vector */
-static unsigned long long mt[NN];
+static uint64_t mt[NN];
 /* mti==NN+1 means mt[NN] is not initialized */
 static int mti = NN + 1;
 
 /* initializes mt[NN] with a seed */
-void mt19937_init(unsigned long long seed)
+void mt19937_init(uint64_t seed)
 {
     mt[0] = seed;
     for (mti = 1; mti < NN; mti++)
@@ -78,11 +78,11 @@ void mt19937_init(unsigned long long seed)
 }
 
 /* generates a random number on [0, 2^64-1]-interval */
-unsigned long long mt19937_rand(void)
+uint64_t mt19937_rand(void)
 {
     int i;
-    unsigned long long x;
-    static unsigned long long mag01[2] = {0ULL, MATRIX_A};
+    uint64_t x;
+    static uint64_t mag01[2] = {0ULL, MATRIX_A};
 
     if (mti >= NN) { /* generate NN words at one time */
 

--- a/mt19937-64.h
+++ b/mt19937-64.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <stdint.h>
+
 /* initializes mt[NN] with a seed */
-void mt19937_init(unsigned long long seed);
+void mt19937_init(uint64_t seed);
 
 /* generates a random number on [0, 2^64-1]-interval */
-unsigned long long mt19937_rand(void);
+uint64_t mt19937_rand(void);

--- a/zobrist.c
+++ b/zobrist.c
@@ -4,7 +4,7 @@
 #include "mt19937-64.h"
 #include "zobrist.h"
 
-unsigned long long zobrist_table[N_GRIDS][2];
+uint64_t zobrist_table[N_GRIDS][2];
 
 #define HASH(key) ((key) % HASH_TABLE_SIZE)
 
@@ -23,7 +23,7 @@ void zobrist_init(void)
         INIT_HLIST_HEAD(&hash_table[i]);
 }
 
-zobrist_entry_t *zobrist_get(unsigned long long key)
+zobrist_entry_t *zobrist_get(uint64_t key)
 {
     unsigned long long hash_key = HASH(key);
 
@@ -44,7 +44,7 @@ zobrist_entry_t *zobrist_get(unsigned long long key)
     return NULL;
 }
 
-void zobrist_put(unsigned long long key, int score, int move)
+void zobrist_put(uint64_t key, int score, int move)
 {
     unsigned long long hash_key = HASH(key);
     zobrist_entry_t *new_entry = malloc(sizeof(zobrist_entry_t));

--- a/zobrist.h
+++ b/zobrist.h
@@ -1,20 +1,22 @@
 #pragma once
 
+#include <stdint.h>
+
 #include "game.h"
 #include "list.h"
 
 #define HASH_TABLE_SIZE ((int) 1e6 + 3)  // choose a large prime number
 
-extern unsigned long long zobrist_table[N_GRIDS][2];
+extern uint64_t zobrist_table[N_GRIDS][2];
 
 typedef struct {
-    unsigned long long key;
+    uint64_t key;
     int score;
     int move;
     struct hlist_node ht_list;
 } zobrist_entry_t;
 
 void zobrist_init(void);
-zobrist_entry_t *zobrist_get(unsigned long long key);
-void zobrist_put(unsigned long long key, int score, int move);
+zobrist_entry_t *zobrist_get(uint64_t key);
+void zobrist_put(uint64_t key, int score, int move);
 void zobrist_clear(void);


### PR DESCRIPTION
The data type unsigned long long does not guarantee a specific bit width, which can lead to potential portability issues across different architectures. To ensure consistency and portability, replace occurrences of unsigned long long with the fixed-width integer type uint64_t.