### PR TITLE
Reject letter input without row number

### DIFF
--- a/main.c
+++ b/main.c
@@ -90,6 +90,9 @@ static int get_input(char player)
             x = y = 0;
             break;
         }
+        // input does not have row number
+        if (x > 0 && x <= BOARD_SIZE && parseX == 1)
+            printf("Invalid operation: No row number\n");
         x -= 1;
         y -= 1;
     }


### PR DESCRIPTION
This patch improves input validation by ensuring that a letter input must be followed by a row number. If the user enters only a letter within the valid board range without a corresponding row number, an error message is displayed. This enhances clarity and prevents invalid moves, ensuring correct input handling.

Before
```shell
$ ./ttt
 1 |             
 2 |             
 3 |             
 4 |             
---+-------------
      A  B  C  D
X> 1
Invalid operation: No leading alphabet
X> 2
Invalid operation: No leading alphabet
X> a
X> b
X> c
X> d
X> e
Invalid operation: index exceeds board size
X> ^C
$
```
After
```shell
$ ./ttt
 1 |             
 2 |             
 3 |             
 4 |             
---+-------------
      A  B  C  D
X> 1
Invalid operation: No leading alphabet
X> 2
Invalid operation: No leading alphabet
X> a
Invalid operation: No row number
X> b
Invalid operation: No row number
X> c
Invalid operation: No row number
X> d
Invalid operation: No row number
X> e
Invalid operation: index exceeds board size
X> f
Invalid operation: index exceeds board size
X> ^C
$
```