### PR TITLE
Fix memory leak in get_input when getline fails

### DIFF
--- a/main.c
+++ b/main.c
@@ -48,8 +48,10 @@ static int get_input(char player)
     while (x < 0 || x > (BOARD_SIZE - 1) || y < 0 || y > (BOARD_SIZE - 1)) {
         printf("%c> ", player);
         int r = getline(&line, &line_length, stdin);
-        if (r == -1)
+        if (r == -1) {
+            free(line);
             exit(1);
+        }
         if (r < 2)
             continue;
         x = 0;


### PR DESCRIPTION
If getline() fails, we should free the pre-allocated line buffer to avoid memory leaks. If line is NULL, calling free(NULL) is safe according to the C99 specification (Section 7.20.3.2).

This ensures proper memory management in case of input failure.

**C99 (7.20.3.2.2)**
> The free function causes the space pointed to by ptr to be deallocated, that is, made available for further allocation. **If ptr is a null pointer, no action occurs.**