### PR TITLE
Reject multiple column letters in get_input

### DIFF
--- a/main.c
+++ b/main.c
@@ -59,6 +59,14 @@ static int get_input(char player)
         parseX = 1;
         for (int i = 0; i < (r - 1); i++) {
             if (isalpha(line[i]) && parseX) {
+                // input has multiple column alphabets
+                if (i > 0 && isalpha(line[i])) {
+                    printf(
+                        "Invalid operation: multiple column alphabets "
+                        "detected\n");
+                    x = y = 0;
+                    break;
+                }
                 x = x * 26 + (tolower(line[i]) - 'a' + 1);
                 if (x > BOARD_SIZE) {
                     // could be any value in [BOARD_SIZE + 1, INT_MAX]
@@ -92,7 +100,7 @@ static int get_input(char player)
             x = y = 0;
             break;
         }
-        // input does not have row number
+        // input does not have row numbers
         if (x > 0 && x <= BOARD_SIZE && parseX == 1)
             printf("Invalid operation: No row number\n");
         x -= 1;


### PR DESCRIPTION
This update adds validation to reject inputs with multiple column letters, such as "aa", which were previously treated as out of bounds instead of being explicitly rejected.

Additionally, a comment was updated for clarity, changing "row number" to "row numbers" for consistency. #38 

Before
```shell
$ ./ttt
 1 |             
 2 |             
 3 |             
 4 |             
---+-------------
      A  B  C  D
X> a5
Invalid operation: index exceeds board size
X> aa
Invalid operation: index exceeds board size
X> aa5
Invalid operation: index exceeds board size
X> d5
Invalid operation: index exceeds board size
X> dd
Invalid operation: index exceeds board size
X> ^C
$
```

After
```shell
$ ./ttt
 1 |             
 2 |             
 3 |             
 4 |             
---+-------------
      A  B  C  D
X> a5
Invalid operation: index exceeds board size
X> aa
Invalid operation: multiple column alphabets detected
X> aa5
Invalid operation: multiple column alphabets detected
X> d5
Invalid operation: index exceeds board size
X> dd
Invalid operation: multiple column alphabets detected
X> ^C
$
```