### PR TITLE
Reject row number 0 as invalid input

### DIFF
--- a/main.c
+++ b/main.c
@@ -85,6 +85,12 @@ static int get_input(char player)
             parseX = 0;
             if (isdigit(line[i])) {
                 y = y * 10 + line[i] - '0';
+                // index cannot be 0
+                if (y == 0) {
+                    printf("Invalid operation: index cannot be 0\n");
+                    x = y = 0;
+                    break;
+                }
                 if (y > BOARD_SIZE) {
                     // could be any value in [BOARD_SIZE + 1, INT_MAX]
                     y = BOARD_SIZE + 1;


### PR DESCRIPTION
This update adds validation to reject row number `0`, which was previously allowed. While row numbers exceeding `BOARD_SIZE` were already handled, there was no explicit check for `0`. An error is now triggered when `0` is entered.

Before
```shell
$ ./ttt
 1 |             
 2 |             
 3 |             
 4 |             
---+-------------
      A  B  C  D
X> a0
X> b0
X> a5
Invalid operation: index exceeds board size
X> ^C
$
```
After
```shell
$ ./ttt
 1 |             
 2 |             
 3 |             
 4 |             
---+-------------
      A  B  C  D
X> a0
Invalid operation: index cannot be 0
X> b0
Invalid operation: index cannot be 0
X> a5
Invalid operation: index exceeds board size
X> ^C
$ 
```