### PR TITLE
Reorder statements to improve spatial locality

### DIFF
--- a/game.c
+++ b/game.c
@@ -19,8 +19,8 @@ _Static_assert(ALLOW_EXCEED == 0 || ALLOW_EXCEED == 1,
                "ALLOW_EXCEED must be a boolean that is 0 or 1");
 
 const line_t lines[4] = {
-    {1, 0, 0, 0, BOARD_SIZE - GOAL + 1, BOARD_SIZE},             // COL
     {0, 1, 0, 0, BOARD_SIZE, BOARD_SIZE - GOAL + 1},             // ROW
+    {1, 0, 0, 0, BOARD_SIZE - GOAL + 1, BOARD_SIZE},             // COL
     {1, 1, 0, 0, BOARD_SIZE - GOAL + 1, BOARD_SIZE - GOAL + 1},  // PRIMARY
     {1, -1, 0, GOAL - 1, BOARD_SIZE - GOAL + 1, BOARD_SIZE},     // SECONDARY
 };


### PR DESCRIPTION
Since row-wise and column-wise checks are logically equivalent in terms of win probability, evaluating row-wise directions first is more favorable due to better spatial locality.

This reordering does not alter functional behavior but may lead to more efficient execution in practice.